### PR TITLE
bump evaluate to `0.3.0`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ dill==0.3.5.1
 docker-pycreds==0.4.0
 efficientnet-pytorch==0.7.1
 einops==0.3.2
-evaluate==0.2.2
+evaluate==0.3.0
 filelock==3.3.0
 fsspec==2022.8.2
 future==0.18.2


### PR DESCRIPTION
There is an issue with `evaluate` before 0.3.0 concerning the Hugging Face hub integration. I suggest upgrading to `0.3.0` which should not have any breaking changes and be functionally equivalent since this version might break in a few months.